### PR TITLE
Smarter routing: skip completed maps, optional weight-aware routes

### DIFF
--- a/ExileMaps.Pathfinding.cs
+++ b/ExileMaps.Pathfinding.cs
@@ -94,35 +94,44 @@ public partial class ExileMapsCore
         return (path, anchorWeight);
     }
 
-    // Plain BFS over the adjacency graph from `from` to `to`. Returns [from, ..., to], or null if
-    // unreachable. Used to build tour segments between two arbitrary cache nodes.
-    private List<Node> FindPath(Node from, Node to)
+    // Cheapest path from `from` to `to`. Each fresh map costs 1; nodes already completed (visited, or
+    // in `done` - corridors/stops committed earlier in the same tour) cost 0. Among equal-cost paths
+    // prefer the highest summed weight of the fresh nodes. Returns [from, ..., to] with its cost, or
+    // (null, 0) if unreachable. Dijkstra on (cost, -weight); graph is ~1000 nodes so this is cheap.
+    private (List<Node> path, int cost) FindPath(Node from, Node to, HashSet<Vector2i> done = null)
     {
-        if (from == null || to == null) return null;
-        if (from.Coordinates == to.Coordinates) return new List<Node> { from };
+        if (from == null || to == null) return (null, 0);
+        if (from.Coordinates == to.Coordinates) return (new List<Node> { from }, 0);
 
+        var cost = new Dictionary<Vector2i, int> { [from.Coordinates] = 0 };
+        var weight = new Dictionary<Vector2i, float> { [from.Coordinates] = 0f };
         var parent = new Dictionary<Vector2i, Node> { [from.Coordinates] = null };
-        var queue = new Queue<Node>();
-        queue.Enqueue(from);
+        var pq = new PriorityQueue<Node, (int cost, float negWeight)>();
+        pq.Enqueue(from, (0, 0f));
 
-        while (queue.Count > 0)
+        while (pq.TryDequeue(out var current, out var pri))
         {
-            var current = queue.Dequeue();
-            foreach (var neighbor in current.Neighbors.Values)
+            var c = current.Coordinates;
+            if (pri.cost > cost[c] || (pri.cost == cost[c] && -pri.negWeight < weight[c])) continue; // stale
+            if (c == to.Coordinates) break;
+            foreach (var nb in current.Neighbors.Values)
             {
-                if (neighbor == null || parent.ContainsKey(neighbor.Coordinates)) continue;
-                parent[neighbor.Coordinates] = current;
-                if (neighbor.Coordinates == to.Coordinates)
-                {
-                    var path = new List<Node>();
-                    for (Node n = neighbor; n != null; n = parent[n.Coordinates]) path.Add(n);
-                    path.Reverse(); // from -> to
-                    return path;
-                }
-                queue.Enqueue(neighbor);
+                if (nb == null) continue;
+                bool free = nb.IsVisited || nb.IsCompleted || (done != null && done.Contains(nb.Coordinates));
+                int nc = cost[c] + (free ? 0 : 1);
+                float nw = weight[c] + (free ? 0f : nb.Weight);
+                if (cost.TryGetValue(nb.Coordinates, out int oc) && (oc < nc || (oc == nc && weight[nb.Coordinates] >= nw)))
+                    continue;
+                cost[nb.Coordinates] = nc; weight[nb.Coordinates] = nw; parent[nb.Coordinates] = current;
+                pq.Enqueue(nb, (nc, -nw));
             }
         }
-        return null;
+
+        if (!parent.ContainsKey(to.Coordinates)) return (null, 0);
+        var path = new List<Node>();
+        for (Node n = to; n != null; n = parent[n.Coordinates]) path.Add(n);
+        path.Reverse(); // from -> to
+        return (path, cost[to.Coordinates]);
     }
 
     // Multi-source BFS from all visited nodes. Returns step distances from the explored region;

--- a/ExileMaps.Pathfinding.cs
+++ b/ExileMaps.Pathfinding.cs
@@ -13,125 +13,82 @@ namespace ExileMaps;
 
 public partial class ExileMapsCore
 {
-    // BFS from destination to nearest visited node (anchor). Among equal-length paths, picks highest
-    // summed weight. Returns [anchor, ..., destination] plus weight, or (null, 0) if unreachable.
-    private (List<Node> path, float weight) FindPathToNearestCompleted(Node destination)
+    // Per-node routing cost. Completed nodes (visited, or in `done`) are free. A fresh map costs 1, or
+    // with weight-aware routing (`extraMapCost` set: extraMapCost - weight, clamped >= 0): a map worth
+    // more than the cost of running one extra map is free to detour through, a worse one costs the difference.
+    private static float RouteCost(Node n, HashSet<Vector2i> done, float? extraMapCost, out bool fresh)
     {
-        if (destination == null)
-            return (null, 0f);
-
-        // Destination already completed: trivial one-node path.
-        if (destination.IsVisited)
-            return (new List<Node> { destination }, destination.Weight);
-
-        var dist = new Dictionary<Vector2i, int>();
-        var best = new Dictionary<Vector2i, float>();    // max accumulated weight among shortest paths
-        var parent = new Dictionary<Vector2i, Node>();
-        var queue = new Queue<Node>();
-
-        dist[destination.Coordinates] = 0;
-        best[destination.Coordinates] = destination.Weight;
-        parent[destination.Coordinates] = null;
-        queue.Enqueue(destination);
-
-        int anchorDist = int.MaxValue;
-        float anchorWeight = float.NegativeInfinity;
-        Node anchor = null;
-
-        while (queue.Count > 0)
-        {
-            var current = queue.Dequeue();
-            int cd = dist[current.Coordinates];
-
-            // All nodes at anchorDist are dequeued before farther nodes (FIFO); stop once past it.
-            if (cd > anchorDist)
-                break;
-
-            // Visited node: candidate anchor. Don't expand; route ends here. Prefer nearest, then heaviest.
-            if (current.IsVisited && current.Coordinates != destination.Coordinates)
-            {
-                float w = best[current.Coordinates];
-                if (cd < anchorDist || (cd == anchorDist && w > anchorWeight))
-                {
-                    anchorDist = cd;
-                    anchorWeight = w;
-                    anchor = current;
-                }
-                continue;
-            }
-
-            foreach (var neighbor in current.Neighbors.Values)
-            {
-                if (neighbor == null)
-                    continue;
-                int nd = cd + 1;
-                // Skip visited nodes in path weight (pinned to 500; only the anchor appears).
-                float nw = best[current.Coordinates] + (neighbor.IsVisited ? 0f : neighbor.Weight);
-                if (!dist.TryGetValue(neighbor.Coordinates, out int existing))
-                {
-                    dist[neighbor.Coordinates] = nd;
-                    best[neighbor.Coordinates] = nw;
-                    parent[neighbor.Coordinates] = current;
-                    queue.Enqueue(neighbor);
-                }
-                else if (existing == nd && nw > best[neighbor.Coordinates])
-                {
-                    // Equal-distance alternative with a higher summed weight: prefer it.
-                    best[neighbor.Coordinates] = nw;
-                    parent[neighbor.Coordinates] = current;
-                }
-            }
-        }
-
-        if (anchor == null)
-            return (null, 0f);
-
-        // Walk parent links from anchor toward destination to reconstruct the path.
-        var path = new List<Node>();
-        for (Node n = anchor; n != null; n = parent[n.Coordinates])
-            path.Add(n);
-
-        return (path, anchorWeight);
+        fresh = !(n.IsVisited || n.IsCompleted || (done != null && done.Contains(n.Coordinates)));
+        if (!fresh) return 0f;
+        if (extraMapCost == null) return 1f;
+        return Math.Max(0f, extraMapCost.Value - n.Weight);
     }
 
-    // Cheapest path from `from` to `to`. Each fresh map costs 1; nodes already completed (visited, or
-    // in `done` - corridors/stops committed earlier in the same tour) cost 0. Among equal-cost paths
-    // prefer the highest summed weight of the fresh nodes. Returns [from, ..., to] with its cost, or
-    // (null, 0) if unreachable. Dijkstra on (cost, -weight); graph is ~1000 nodes so this is cheap.
-    private (List<Node> path, int cost) FindPath(Node from, Node to, HashSet<Vector2i> done = null)
-    {
-        if (from == null || to == null) return (null, 0);
-        if (from.Coordinates == to.Coordinates) return (new List<Node> { from }, 0);
+    // Tours / Waypoints each have their own toggle + cost; null = weight-aware routing off.
+    private float? TourExtraMapCost => Settings.Tours.WeightAwareRouting ? Settings.Tours.ExtraMapCost.Value : null;
+    private float? WaypointExtraMapCost => Settings.Waypoints.WeightAwareRouting ? Settings.Waypoints.ExtraMapCost : null;
 
-        var cost = new Dictionary<Vector2i, int> { [from.Coordinates] = 0 };
-        var weight = new Dictionary<Vector2i, float> { [from.Coordinates] = 0f };
-        var parent = new Dictionary<Vector2i, Node> { [from.Coordinates] = null };
-        var pq = new PriorityQueue<Node, (int cost, float negWeight)>();
-        pq.Enqueue(from, (0, 0f));
+    // Shared Dijkstra core. Expands from `start` until a node satisfying `isGoal` is popped. Priority
+    // is (route cost, fresh-map count, -summed weight), so without weight-aware routing this is
+    // "fewest maps, then heaviest". Goal nodes are never expanded. Returns [start, ..., goal] plus the
+    // fresh-map count and summed fresh weight, or (null, 0, 0) if no goal is reachable.
+    private (List<Node> path, int steps, float weight) Route(Node start, Func<Node, bool> isGoal, HashSet<Vector2i> done, float? extraMapCost)
+    {
+        var best = new Dictionary<Vector2i, (float cost, int steps, float weight)> { [start.Coordinates] = (0f, 0, 0f) };
+        var parent = new Dictionary<Vector2i, Node> { [start.Coordinates] = null };
+        var pq = new PriorityQueue<Node, (float cost, int steps, float negWeight)>();
+        pq.Enqueue(start, (0f, 0, 0f));
+
+        static bool Better((float cost, int steps, float weight) a, (float cost, int steps, float weight) b)
+            => a.cost < b.cost || (a.cost == b.cost && (a.steps < b.steps || (a.steps == b.steps && a.weight > b.weight)));
 
         while (pq.TryDequeue(out var current, out var pri))
         {
             var c = current.Coordinates;
-            if (pri.cost > cost[c] || (pri.cost == cost[c] && -pri.negWeight < weight[c])) continue; // stale
-            if (c == to.Coordinates) break;
+            var cur = best[c];
+            if (Better(cur, (pri.cost, pri.steps, -pri.negWeight))) continue; // stale entry
+            if (isGoal(current))
+            {
+                var path = new List<Node>();
+                for (Node n = current; n != null; n = parent[n.Coordinates]) path.Add(n);
+                path.Reverse(); // start -> goal
+                return (path, cur.steps, cur.weight);
+            }
             foreach (var nb in current.Neighbors.Values)
             {
                 if (nb == null) continue;
-                bool free = nb.IsVisited || nb.IsCompleted || (done != null && done.Contains(nb.Coordinates));
-                int nc = cost[c] + (free ? 0 : 1);
-                float nw = weight[c] + (free ? 0f : nb.Weight);
-                if (cost.TryGetValue(nb.Coordinates, out int oc) && (oc < nc || (oc == nc && weight[nb.Coordinates] >= nw)))
-                    continue;
-                cost[nb.Coordinates] = nc; weight[nb.Coordinates] = nw; parent[nb.Coordinates] = current;
-                pq.Enqueue(nb, (nc, -nw));
+                float step = RouteCost(nb, done, extraMapCost, out bool fresh);
+                var cand = (cur.cost + step, cur.steps + (fresh ? 1 : 0), cur.weight + (fresh ? nb.Weight : 0f));
+                if (best.TryGetValue(nb.Coordinates, out var old) && !Better(cand, old)) continue;
+                best[nb.Coordinates] = cand; parent[nb.Coordinates] = current;
+                pq.Enqueue(nb, (cand.Item1, cand.Item2, -cand.Item3));
             }
         }
+        return (null, 0, 0f);
+    }
 
-        if (!parent.ContainsKey(to.Coordinates)) return (null, 0);
-        var path = new List<Node>();
-        for (Node n = to; n != null; n = parent[n.Coordinates]) path.Add(n);
-        path.Reverse(); // from -> to
-        return (path, cost[to.Coordinates]);
+    // Route from destination to the nearest visited node (anchor). Used for waypoint routes and a tour's
+    // lead-in; the caller passes its own extra-map cost (null = off). Returns [anchor, ..., destination]
+    // plus summed weight, or (null, 0) if unreachable.
+    private (List<Node> path, float weight) FindPathToNearestCompleted(Node destination, float? extraMapCost)
+    {
+        if (destination == null) return (null, 0f);
+        if (destination.IsVisited) return (new List<Node> { destination }, destination.Weight);
+
+        var (path, _, weight) = Route(destination, n => n.IsVisited && n.Coordinates != destination.Coordinates, null, extraMapCost);
+        if (path == null) return (null, 0f);
+        path.Reverse(); // anchor -> destination
+        return (path, weight + destination.Weight);
+    }
+
+    // Tour segment (Tours.WeightAwareRouting). `done` = nodes committed earlier in the same tour (free to reuse).
+    // Returns [from, ..., to] plus the number of fresh maps on it, or (null, 0) if unreachable.
+    private (List<Node> path, int steps) FindPath(Node from, Node to, HashSet<Vector2i> done = null)
+    {
+        if (from == null || to == null) return (null, 0);
+        if (from.Coordinates == to.Coordinates) return (new List<Node> { from }, 0);
+        var (path, steps, _) = Route(from, n => n.Coordinates == to.Coordinates, done, TourExtraMapCost);
+        return (path, steps);
     }
 
     // Multi-source BFS from all visited nodes. Returns step distances from the explored region;
@@ -253,7 +210,7 @@ public partial class ExileMapsCore
         {
             if (mapCache.TryGetValue(waypoint.Coordinates, out Node waypointNode))
             {
-                var (path, weight) = FindPathToNearestCompleted(waypointNode);
+                var (path, weight) = FindPathToNearestCompleted(waypointNode, WaypointExtraMapCost);
                 waypoint.PathFromStart = path;
                 waypoint.PathWeight = weight;
             }

--- a/ExileMaps.Tours.cs
+++ b/ExileMaps.Tours.cs
@@ -1,4 +1,4 @@
-// Named tours: build, optimize, draw, Tours panel, Build Mode, panel button bar.
+﻿// Named tours: build, optimize, draw, Tours panel, Build Mode, panel button bar.
 using System;
 using System.Collections.Generic;
 using System.Drawing;
@@ -167,13 +167,16 @@ public partial class ExileMapsCore
             t.Segments.Add(incoming ?? new List<Node> { first });
             t.ResolvedStops.Add(first);
 
+            // Nodes the tour will have completed by the time each later segment is walked: free to reuse.
+            var done = new HashSet<Vector2i>(t.Segments[0].Select(n => n.Coordinates));
             Node anchor = first;
             for (int i = 1; i < nodes.Count; i++)
             {
-                var path = FindPath(anchor, nodes[i]);
+                var (path, _) = FindPath(anchor, nodes[i], done);
                 if (path == null) { t.Skipped.Add(nodes[i].Name ?? $"(stop {i + 1})"); continue; }
                 t.Segments.Add(path);
                 t.ResolvedStops.Add(nodes[i]);
+                done.UnionWith(path.Select(n => n.Coordinates));
                 anchor = nodes[i];
             }
 
@@ -217,18 +220,21 @@ public partial class ExileMapsCore
             ordered.Add(current);
             remaining.Remove(current);
 
+            var done = new HashSet<Vector2i>();
             while (remaining.Count > 0)
             {
                 List<Node> bestPath = null;
+                int bestCost = int.MaxValue;
                 Node bestNode = null;
                 foreach (var cand in remaining)
                 {
-                    var path = FindPath(current, cand);
+                    var (path, cost) = FindPath(current, cand, done);
                     if (path == null) continue;
-                    if (bestPath == null || path.Count < bestPath.Count) { bestPath = path; bestNode = cand; }
+                    if (cost < bestCost) { bestPath = path; bestCost = cost; bestNode = cand; }
                 }
                 // Unreachable from current: fall back to nearest-to-frontier among the rest.
                 if (bestNode == null) bestNode = remaining.OrderBy(Steps).First();
+                else done.UnionWith(bestPath.Select(n => n.Coordinates));
                 ordered.Add(bestNode);
                 remaining.Remove(bestNode);
                 current = bestNode;
@@ -555,19 +561,21 @@ public partial class ExileMapsCore
             var chain = new List<Node> { start };
             var remaining = candidates.Where(c => !ReferenceEquals(c, start)).ToList();
             Node current = start;
+            var done = new HashSet<Vector2i>();
             while (remaining.Count > 0)
             {
                 Node best = null;
+                List<Node> bestPath = null;
                 int bestSteps = int.MaxValue;
                 foreach (var cand in remaining)
                 {
-                    var path = FindPath(current, cand);
+                    var (path, steps) = FindPath(current, cand, done); // steps = fresh maps to run
                     if (path == null) continue;
-                    int steps = path.Count - 1;
                     if (steps > n) continue;                 // out of range
-                    if (steps < bestSteps) { bestSteps = steps; best = cand; }
+                    if (steps < bestSteps) { bestSteps = steps; best = cand; bestPath = path; }
                 }
                 if (best == null) break;                     // no valid content within N steps
+                done.UnionWith(bestPath.Select(x => x.Coordinates));
                 chain.Add(best);
                 remaining.Remove(best);
                 current = best;

--- a/ExileMaps.Tours.cs
+++ b/ExileMaps.Tours.cs
@@ -163,7 +163,7 @@ public partial class ExileMapsCore
             if (nodes.Count == 0) { t.BuiltVersion = mapCacheVersion; return; }
 
             var first = nodes[0];
-            var (incoming, _) = FindPathToNearestCompleted(first);
+            var (incoming, _) = FindPathToNearestCompleted(first, TourExtraMapCost);
             t.Segments.Add(incoming ?? new List<Node> { first });
             t.ResolvedStops.Add(first);
 
@@ -596,6 +596,24 @@ public partial class ExileMapsCore
         catch (Exception e) { LogError("Error auto-creating tour: " + e.Message); }
     }
 
+    private void DrawTourRoutingControls()
+    {
+        bool changed = false;
+        bool weightAware = Settings.Tours.WeightAwareRouting;
+        if (ImGui.Checkbox("Weight-aware routing", ref weightAware)) { Settings.Tours.WeightAwareRouting.Value = weightAware; changed = true; }
+        if (ImGui.IsItemHovered()) ImGui.SetTooltip("Take a longer tour when the extra maps are worth it. Off = fewest maps, weight only breaks ties.");
+        if (weightAware)
+        {
+            ImGui.SameLine();
+            float extraCost = Settings.Tours.ExtraMapCost;
+            ImGui.SetNextItemWidth(140);
+            if (ImGui.SliderFloat("Extra map cost", ref extraCost, 0f, 100f, "%.0f")) { Settings.Tours.ExtraMapCost.Value = extraCost; changed = true; }
+            if (ImGui.IsItemHovered()) ImGui.SetTooltip("Weight-aware routing: each map to run costs (this - map weight, min 0), cheapest route wins. Set it near the weight of a map you'd call fine.");
+        }
+        if (changed)
+            foreach (var t in Settings.Tours.Tours.Values) t.BuiltVersion = -1;
+    }
+
     // ---- UI ----
 
     private string StopLabel(TourStop s)
@@ -690,6 +708,8 @@ public partial class ExileMapsCore
                 if (ImGui.Button(buildModeActive ? $"Building... ({Settings.Keybinds.BuildModeExitHotkey.Value})" : "Build Mode")) buildModeActive = !buildModeActive;
                 if (buildModeActive) ImGui.PopStyleColor();
                 if (ImGui.IsItemHovered()) ImGui.SetTooltip("Left-click atlas nodes to add stops to the active tour; right-click removes. Press the Build Mode exit key (default Tab) to exit.");
+
+                DrawTourRoutingControls();
                 ImGui.Separator();
 
                 DrawAutoTourSection();

--- a/ExileMaps.Waypoints.cs
+++ b/ExileMaps.Waypoints.cs
@@ -151,6 +151,23 @@ public partial class ExileMapsCore
         Graphics.DrawQuad(texId, a + n, b + n, b - n, a - n, color);
     }
 
+    private void DrawWaypointRoutingControls()
+    {
+        bool changed = false;
+        bool weightAware = Settings.Waypoints.WeightAwareRouting;
+        if (ImGui.Checkbox("Weight-aware routing", ref weightAware)) { Settings.Waypoints.WeightAwareRouting = weightAware; changed = true; }
+        if (ImGui.IsItemHovered()) ImGui.SetTooltip("Take a longer waypoint route when the extra maps are worth it. Off = fewest maps, weight only breaks ties.");
+        if (weightAware)
+        {
+            ImGui.SameLine();
+            float extraCost = Settings.Waypoints.ExtraMapCost;
+            ImGui.SetNextItemWidth(140);
+            if (ImGui.SliderFloat("Extra map cost", ref extraCost, 0f, 100f, "%.0f")) { Settings.Waypoints.ExtraMapCost = extraCost; changed = true; }
+            if (ImGui.IsItemHovered()) ImGui.SetTooltip("Weight-aware routing: each map to run costs (this - map weight, min 0), cheapest route wins. Set it near the weight of a map you'd call fine.");
+        }
+        if (changed) UpdateWaypointPaths();
+    }
+
     private void DrawWaypointPanel() {
         // Default footprint on first open: inset 30px from the screen's top-left, and 85% of the
         // interface height. Restored from saved rect after; the user can move/resize freely.
@@ -192,6 +209,7 @@ public partial class ExileMapsCore
         }
         ImGui.EndTable();
 
+        DrawWaypointRoutingControls();
         ImGui.Spacing();
 
         ImGui.PushStyleVar(ImGuiStyleVar.ItemSpacing, new Vector2(0, 10));

--- a/ExileMapsSettings.cs
+++ b/ExileMapsSettings.cs
@@ -866,6 +866,12 @@ public class TourSettings
     [Menu("Auto-clear Completed Stops", "When rebuilding a tour, automatically drop stops whose map you've already completed.")]
     public ToggleNode AutoClearCompleted { get; set; } = new ToggleNode(true);
 
+    [Menu("Weight-aware Routing", "Take a longer tour when the extra maps are worth it. Off = fewest maps, weight only breaks ties.")]
+    public ToggleNode WeightAwareRouting { get; set; } = new ToggleNode(false);
+
+    [Menu("Extra Map Cost", "Weight-aware routing: each map to run costs (this - map weight, min 0), cheapest route wins. Set it near the weight of a map you'd call fine.")]
+    public RangeNode<float> ExtraMapCost { get; set; } = new RangeNode<float>(25f, 0f, 100f);
+
     // Id of the tour the Add-Tour-Stop hotkey targets. Empty = none active.
     public string ActiveTourId { get; set; } = "";
 
@@ -1392,6 +1398,8 @@ public class WaypointSettings
     public bool InverWaypointArrowsColors { get; set; } = true;
     public bool AutoWaypointFavorites { get; set; } = false;
     public bool AutoRemoveCompletedWaypoints { get; set; } = true;
+    public bool WeightAwareRouting { get; set; } = false;
+    public float ExtraMapCost { get; set; } = 25f;
 
     public int WaypointPanelMaxItems { get; set; } = 160;
     public int WaypointPanelMaxSteps { get; set; } = 0; // 0 = unlimited
@@ -1475,6 +1483,27 @@ public class WaypointSettings
 
                     ImGui.TableNextColumn();
                     ImGui.Text("Auto Remove Completed Waypoints");
+
+                    // weight-aware routing
+                    ImGui.TableNextRow();
+                    ImGui.TableNextColumn();
+                    bool _weightAware = WeightAwareRouting;
+                    if(ImGui.Checkbox($"##waypoint_weight_aware", ref _weightAware))
+                        WeightAwareRouting = _weightAware;
+                    if (ImGui.IsItemHovered()) ImGui.SetTooltip("Take a longer waypoint route when the extra maps are worth it. Off = fewest maps, weight only breaks ties.");
+
+                    ImGui.TableNextColumn();
+                    ImGui.Text("Weight-aware Routing");
+
+                    // extra map cost
+                    ImGui.TableNextRow();
+                    ImGui.TableNextColumn();
+                    ImGui.TableNextColumn();
+                    float _extraCost = ExtraMapCost;
+                    ImGui.SetNextItemWidth(160);
+                    if (ImGui.SliderFloat("Extra Map Cost##waypoint_extra_cost", ref _extraCost, 0f, 100f, "%.0f"))
+                        ExtraMapCost = _extraCost;
+                    if (ImGui.IsItemHovered()) ImGui.SetTooltip("Weight-aware routing: each map to run costs (this - map weight, min 0), cheapest route wins. Set it near the weight of a map you'd call fine.");
 
                     ImGui.TableNextRow();
 


### PR DESCRIPTION
Two changes to how tours and waypoint routes are calculated.

### 1. Routes count maps you still have to run, not nodes

Previously a route was the fewest *nodes*, with completed maps counted the same as fresh ones. That could pick a route with more maps to actually run when a route with more nodes but fewer fresh maps existed, and tour segments never reused earlier segments. Completed maps are now free (including ones the tour itself will have completed by then), and when two routes need the same number of maps, the one with the higher total weight wins.

| Old | New |
|:---:|:---:|
|<img width="681" height="634" alt="Exiled_Exchange_2_FUEQ1rJvXU" src="https://github.com/user-attachments/assets/b8260670-8bb0-45f8-8f48-dab5108762d2" />  | <img width="659" height="626" alt="Exiled_Exchange_2_ji3uTmi347" src="https://github.com/user-attachments/assets/baa2a206-f7cb-4eec-ae2c-822d18c61a5d" />


### 2. Weight-aware routing (opt-in)

New toggle + slider under **Tours** and under **Waypoints** (also shown in each panel), each with its own setting.

When on, a route may run *more* maps if they're better ones. Each map to run costs `Extra Map Cost − map weight` (never below 0); the cheapest route wins. So a map worth more than the cost is free to detour through, a worse one costs the difference.

Off (default) keeps the fewest-maps behaviour.


In the following example the target can be reached either through one Digsite, one Mineshaft or two Channels. If Channel completion took only 10 seconds vs. 1 minute for the other two maps, I'd always want to run the two Channel maps to reach my target.

| Old | New with Digsite and Mineshaft at -50, Channel at 50|
|:---:|:---:|
| <img width="363" height="366" alt="Exiled_Exchange_2_DHeLrG6nzd" src="https://github.com/user-attachments/assets/b0f1e4de-9592-40db-8afa-500233cbc36a" /> | <img width="423" height="168" alt="Exiled_Exchange_2_pA7MQHcwpl" src="https://github.com/user-attachments/assets/a014ccf2-ac9b-4ba7-a90c-14be70afdf4c" />

---

Both routers now share one Dijkstra core in `ExileMaps.Pathfinding.cs`; the waypoint router's hand-rolled BFS is gone.
